### PR TITLE
Use delete[] instead of delete

### DIFF
--- a/src/kernel.cu
+++ b/src/kernel.cu
@@ -450,8 +450,8 @@ void Boids::unitTest() {
   }
 
   // cleanup
-  delete(intKeys);
-  delete(intValues);
+  delete[] intKeys;
+  delete[] intValues;
   cudaFree(dev_intKeys);
   cudaFree(dev_intValues);
   checkCUDAErrorWithLine("cudaFree failed!");


### PR DESCRIPTION
Since intKeys and intValues were allocated with new int[], should it be deleted with delete[]?
